### PR TITLE
Fix: Preserve numeric values in dynamic table names, preventing removal from the middle or end of the string

### DIFF
--- a/servicenow/plugin.go
+++ b/servicenow/plugin.go
@@ -74,7 +74,8 @@ func pluginTableDefinitions(ctx context.Context, d *plugin.TableMapData) (map[st
 		return tables, nil
 	}
 
-	var re = regexp.MustCompile(`\d+`)
+	// In PostgreSQL, table names must start with a letter (a-z) or an underscore (_). They cannot begin with a number
+	var re = regexp.MustCompile(`^\d+`)
 	var substitution = ``
 	servicenowTables := []string{}
 	servicenowTables = append(servicenowTables, *config.Objects...)


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from servicenow_x_1547783_turbot_guardrails_azure_subscription
+----------------+------------+------------+------------------+------------+----------+-----------+--------------+-------------+---------------------+--------+-------------+--------------------+--------------+--------------------+----------------+----------+----------->
| sys_class_path | gl_account | ip_address | first_discovered | dns_domain | attested | asset_tag | supported_by | assigned_to | warranty_expiration | asset  | subcategory | operational_status | display_name | managed_by_tenants | invoice_number | assigned | install_st>
+----------------+------------+------------+------------------+------------+----------+-----------+--------------+-------------+---------------------+--------+-------------+--------------------+--------------+--------------------+----------------+----------+----------->
| /!!/$$         | <null>     | <null>     | <null>           | <null>     | false    | <null>    | <null>       | <null>      | <null>              | <null> | <null>      | 1                  | Punisher AAA | []                 | <null>         | <null>   | 1         >
| /!!/$$         | <null>     | <null>     | <null>           | <null>     | false    | <null>    | <null>       | <null>      | <null>              | <null> | <null>      | 1                  | Punisher AAA | []                 | <null>         | <null>   | 1         >
+----------------+------------+------------+------------------+------------+----------+-----------+--------------+-------------+---------------------+--------+-------------+--------------------+--------------+--------------------+----------------+----------+----------->
```
</details>
